### PR TITLE
Update Readme.md, fix GPM client auth check

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -15,7 +15,7 @@ This runs locally and absolutely zero information is sent to me or anyone else. 
 * A GPM and Spotify account
 
 ## Setup
-1) Go to the [developer page](developer.spotify.com/dashboard/), make an app/client_id. Add your redirect URL as `http://localhost/`
+1) Go to the [developer page](https://developer.spotify.com/dashboard/), make an app/client_id. Add your redirect URL as `http://localhost/`
 2) `mv .env.example .env`
 3) Populate .env with client_id, secret, redirect url, and username (found when you login online)
 

--- a/Readme.md
+++ b/Readme.md
@@ -41,7 +41,7 @@ Heres a quick way to transfer it
 3) Note the name you gave it, enter it below
 
 ```bash
-pipenv run thumbs_up.py [name of thumbs up playlist]
+pipenv run python3 thumbs_up.py [name of thumbs up playlist]
 ```
 
 ## Known Issues

--- a/main.py
+++ b/main.py
@@ -53,7 +53,7 @@ class GPM_client:
         self.gpm_client = Mobileclient()
 
         # login
-        if not self.gpm_client.is_authenticated():
+        if self.gpm_client.is_authenticated():
             logging.info("Logging you in...")
             self.gpm_client.oauth_login(device_id=Mobileclient.FROM_MAC_ADDRESS)
         else:

--- a/thumbs_up.py
+++ b/thumbs_up.py
@@ -53,7 +53,7 @@ class GPM_client:
         self.gpm_client = Mobileclient()
 
         # login
-        if not self.gpm_client.is_authenticated():
+        if self.gpm_client.is_authenticated():
             logging.info("Logging you in...")
             self.gpm_client.oauth_login(device_id=Mobileclient.FROM_MAC_ADDRESS)
         else:


### PR DESCRIPTION
* Added the protocol to Spotify dashboard URL to fix the link.
* Fixed the example command for running `thumbs_up.py`.
* Fixed gpm client `is_authenticated` checks that were trying to use previous credentials even when there were none and the actual OAuth login was never triggered.